### PR TITLE
Created SpecUtil to handle common api request config and common assertions

### DIFF
--- a/src/test/java/com/api/test/CountAPITest.java
+++ b/src/test/java/com/api/test/CountAPITest.java
@@ -1,16 +1,23 @@
 package com.api.test;
 
-import static org.hamcrest.Matchers.*;
+import static com.api.constant.Role.FD;
+import static com.api.utils.ConfigManager.getProperty;
+import static io.restassured.RestAssured.given;
+import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import static org.hamcrest.Matchers.blankOrNullString;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
 import org.testng.annotations.Test;
 
 import com.api.constant.Role;
 import com.api.utils.AuthTokenProvider;
-
-import static io.restassured.module.jsv.JsonSchemaValidator.*;
-
-import static com.api.utils.ConfigManager.*;
-
-import static io.restassured.RestAssured.*;
+import com.api.utils.SpecUtil;
 
 public class CountAPITest {
 	
@@ -18,19 +25,13 @@ public class CountAPITest {
 	public void verifyCountAPIResponse() {
 		
 		given()
-		.baseUri(getProperty("BASE_URL"))
-		.and()
-		.header("Authorization",AuthTokenProvider.getToken(Role.FD))
-		.log().uri()
-		.log().method()
-		.log().headers()
+		.spec(SpecUtil.requestSpecWithAuth(FD))
 		.when()
 		.get("dashboard/count")
 		.then()
-		.log().all()
-		.statusCode(200)
+		.spec(SpecUtil.responseSpec_OK())
 		.body("message",equalTo("Success"))
-		.time(lessThan(2000L))
+		
 		.body("data",notNullValue())
 		.body("data.size()",equalTo(3))
 		.body("data.count",everyItem(greaterThanOrEqualTo(0)))
@@ -42,17 +43,11 @@ public class CountAPITest {
 	
 	public void countAPTTest_MissingAuthToken() {
 		given()
-		.baseUri(getProperty("BASE_URL"))
-		.and()
-		.header("Authorization",AuthTokenProvider.getToken(Role.FD))
-		.log().uri()
-		.log().method()
-		.log().headers()
+		.spec(SpecUtil.requestSpec())
 		.when()
 		.get("dashboard/count")
 		.then()
-		.log().all()
-		.statusCode(401);
+		.spec(SpecUtil.responseSpec_TEXT(401));
 	}
 
 }

--- a/src/test/java/com/api/test/LoginAPITest.java
+++ b/src/test/java/com/api/test/LoginAPITest.java
@@ -9,9 +9,8 @@ import java.io.IOException;
 import org.testng.annotations.Test;
 
 import com.api.pojo.UserCredentials;
-import  static com.api.utils.ConfigManager.*;
+import com.api.utils.SpecUtil;
 
-import io.restassured.http.ContentType;
 import io.restassured.module.jsv.JsonSchemaValidator;
 
 public class LoginAPITest {
@@ -21,23 +20,11 @@ public class LoginAPITest {
 		UserCredentials userCreds =new UserCredentials("iamfd", "password");
 		
 		given()
-			.baseUri(getProperty("BASE_URL"))
-		.and()
-		.contentType(ContentType.JSON)
-		.and()
-		.accept(ContentType.JSON)
-		.and()
-		.body(userCreds)
-		.log().uri()
-		.log().method()
-		.log().headers()
-		.log().body()
-		.when()
+		.spec(SpecUtil.requestSpec(userCreds))
+        .when()
 		.post("login")
 		.then()
-		.log().all()
-		.statusCode(200)
-		.time(lessThan(2000L))
+		.spec(SpecUtil.responseSpec_OK())
 		.and()
 		.body("message",equalTo("Success"))
 		.and()

--- a/src/test/java/com/api/test/MasterAPITest.java
+++ b/src/test/java/com/api/test/MasterAPITest.java
@@ -5,6 +5,8 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
 import org.testng.annotations.Test;
 
+import com.api.utils.SpecUtil;
+
 import io.restassured.module.jsv.JsonSchemaValidator;
 
 import static com.api.constant.Role.*;
@@ -16,18 +18,11 @@ public class MasterAPITest {
 	@Test
 	public void masterAPI() {
 		given()
-		.baseUri(getProperty("BASE_URL"))
-		.and()
-		.header("Authorization",getToken(FD))
-		.and()
-		.contentType(" ")
-		.log().all()
+		.spec(SpecUtil.requestSpecWithAuth(FD))
 		.when()
 		.post("master")
 		.then()
-		.log().all()
-		.statusCode(200)
-		.time(lessThan(2000L))
+		.spec(SpecUtil.responseSpec_OK())
 		.body("message",equalTo("Success"))
 		.body("data",notNullValue())
 		.body("data",hasKey("mst_oem"))
@@ -42,17 +37,13 @@ public class MasterAPITest {
 	
 	public void invalidTokenMasterAPITest() {
 		given()
-		.baseUri(getProperty("BASE_URL"))
-		.and()
-		.header("Authorization",getToken(FD))
-		.and()
-		.contentType(" ")
+		.spec(SpecUtil.requestSpec())
 		.log().all()
 		.when()
 		.post("master")
 		.then()
-		.log().all()
-		.statusCode(401);
+		.spec(SpecUtil.responseSpec_TEXT(401));
+		
 	}
 
 }

--- a/src/test/java/com/api/test/UserDetailsAPITest.java
+++ b/src/test/java/com/api/test/UserDetailsAPITest.java
@@ -7,6 +7,8 @@ import java.io.IOException;
 
 import org.testng.annotations.Test;
 
+import com.api.utils.SpecUtil;
+
 import static com.api.constant.Role.*;
 
 import static com.api.utils.AuthTokenProvider.*;
@@ -25,21 +27,11 @@ public class UserDetailsAPITest {
 		
 		Header authHeader=new Header("Authorization",getToken(FD));
 		given()
-		.baseUri(getProperty("BASE_URL"))
-		.and()
-		.header(authHeader)
-		.and()
-		.accept(ContentType.JSON)
-		.log().all()
-		.log().uri()
-		.log().method()
-		.log().headers()
+		.spec(SpecUtil.requestSpecWithAuth(FD))
 		.when()
 		.get("userdetails")
 		.then()
-		.log().all()
-		.statusCode(200)
-		.time(lessThan(2000L))
+		.spec(SpecUtil.responseSpec_OK())
 		.and()
 		.body(JsonSchemaValidator.matchesJsonSchemaInClasspath("response-schema/UserDetailsResponseSchema.json"));
 	}

--- a/src/test/java/com/api/utils/SpecUtil.java
+++ b/src/test/java/com/api/utils/SpecUtil.java
@@ -1,0 +1,97 @@
+package com.api.utils;
+import static com.api.utils.ConfigManager.getProperty;
+
+import org.hamcrest.Matchers;
+
+import com.api.constant.Role;
+import com.api.pojo.UserCredentials;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.builder.ResponseBuilder;
+import io.restassured.builder.ResponseSpecBuilder;
+import io.restassured.filter.log.LogDetail;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.specification.ResponseSpecification;
+
+public class SpecUtil {
+	
+	//GET--DEL
+	public static RequestSpecification requestSpec() {
+		
+		RequestSpecification requestSpecification=new RequestSpecBuilder()
+		.setBaseUri(getProperty("BASE_URL"))
+		.setContentType(ContentType.JSON)
+		.setAccept(ContentType.JSON)
+		.log(LogDetail.URI)
+		.log(LogDetail.METHOD)
+		.log(LogDetail.HEADERS)
+		.log(LogDetail.BODY)
+		.build();
+		return requestSpecification;
+		
+	}
+	
+	//POST-PUT-PATCH{BODY}
+	
+public static RequestSpecification requestSpec(Object userCreds) {
+		
+		RequestSpecification requestSpecification =new RequestSpecBuilder()
+		.setBaseUri(getProperty("BASE_URL"))
+		.setContentType(ContentType.JSON)
+		.setAccept(ContentType.JSON)
+		.setBody(userCreds)
+		.log(LogDetail.URI)
+		.log(LogDetail.METHOD)
+		.log(LogDetail.HEADERS)
+		.log(LogDetail.BODY)
+		.build();
+		return requestSpecification;
+		
+	}
+
+public static RequestSpecification requestSpecWithAuth(Role role) {
+	RequestSpecification requestSpecification =new RequestSpecBuilder()
+	.setBaseUri(getProperty("BASE_URL"))
+	.setContentType(ContentType.JSON)
+	.setAccept(ContentType.JSON)
+	.setAccept(ContentType.JSON)
+	.addHeader("Authorization",AuthTokenProvider.getToken(role))
+	.log(LogDetail.URI)
+	.log(LogDetail.METHOD)
+	.log(LogDetail.HEADERS)
+	.log(LogDetail.BODY)
+	.build();
+	return requestSpecification;
+	
+}
+
+public static ResponseSpecification responseSpec_OK() {
+	ResponseSpecification reponseSpecification=new ResponseSpecBuilder()
+	.expectContentType(ContentType.JSON)
+	.expectStatusCode(200)
+	.expectResponseTime(Matchers.lessThan(1000l))
+	.log(LogDetail.ALL)
+	.build();
+	return reponseSpecification;
+}
+
+public static ResponseSpecification responseSpec(int statusCode) {
+	ResponseSpecification reponseSpecification=new ResponseSpecBuilder()
+	.expectContentType(ContentType.JSON)
+	.expectStatusCode(statusCode)
+	.expectResponseTime(Matchers.lessThan(1000l))
+	.log(LogDetail.ALL)
+	.build();
+	return reponseSpecification;
+}
+
+public static ResponseSpecification responseSpec_TEXT(int statusCode) {
+	ResponseSpecification reponseSpecification=new ResponseSpecBuilder()
+	.expectStatusCode(statusCode)
+	.expectResponseTime(Matchers.lessThan(1000l))
+	.log(LogDetail.ALL)
+	.build();
+	return reponseSpecification;
+}
+}


### PR DESCRIPTION
SpecUtil is consisting of common RequestSpecBuilder and ResponseSpecBuilder. These utils methods has reduced the boiler plate coed is our api tests, and also reduced the number of lines. Making test code smaller and maintainable